### PR TITLE
Corrected multi device support

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -90,13 +90,13 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    dnum = 0;
+    dnum = -1;
     deckLink = NULL;
     while (deckLinkIterator->Next(&deckLink) == S_OK)
     {
         char    *deviceNameString = NULL;
         // Target the correct card if deviceNumber been specified (or defaults to 0)
-        if ((deviceNumber > 0) && (dnum != deviceNumber))
+        if ((deviceNumber > -1) && (dnum != deviceNumber))
         {
             deckLink->Release();
             dnum++;


### PR DESCRIPTION
While setting card 0 also other cards got switched as well due to 0 being explicitly set even if not specified as parameter:

```
# ./decklinkpreferences -p 2 -d 0
Configure Input port to 2
Current port: 1
Setting card 0's input port to 2
Current port: 2
Setting card 1's input port to 2
```