### PR TITLE
Corrected multi-device support

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -90,13 +90,13 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    dnum = 0;
+    dnum = -1;
     deckLink = NULL;
     while (deckLinkIterator->Next(&deckLink) == S_OK)
     {
         char    *deviceNameString = NULL;
         // Target the correct card if deviceNumber been specified (or defaults to 0)
-        if ((deviceNumber > 0) && (dnum != deviceNumber))
+        if ((deviceNumber > -1) && (dnum != deviceNumber))
         {
             deckLink->Release();
             dnum++;

--- a/main.cpp
+++ b/main.cpp
@@ -30,7 +30,8 @@ int main(int argc, char *argv[])
     char        *appName = argv[0];
     int         ch;
     int64_t     ports = -1;
-    int         dnum, deviceNumber = 0;
+    int         dnum = 0;
+    int         deviceNumber = -1;
     int         inputPort = -1;
     bool        deviceNumberIsDefault = true;
     bool        displayHelp = false;
@@ -90,7 +91,6 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    dnum = -1;
     deckLink = NULL;
     while (deckLinkIterator->Next(&deckLink) == S_OK)
     {


### PR DESCRIPTION
When setting device number 0 the comparisons for skipping cycle get incorrectly evaluated setting the port on all cards instead of specified one.

If you want to test something on system with 2 DeckLink Recorder cards just let me know.