### PR TITLE
Use system variables during building

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Blackmagic Design SDK is required to build from source code.
 
 Run:
 ```
-	qmake
+	qmake SDK_PATH=path_to_your_black_magic_sdk_include_catalog
 	make
 ```
 to produce the _decklinkpreferences_ executable.

--- a/decklinkpreferences.pro
+++ b/decklinkpreferences.pro
@@ -15,10 +15,10 @@ CONFIG   -= app_bundle
 TEMPLATE = app
 
 
-INCLUDEPATH += $HOME/pixelizator/bmdtools/Linux/include
+INCLUDEPATH += $${SDK_PATH}
 
 SOURCES += main.cpp \
-        $HOME/pixelizator/bmdtools/Linux/include/DeckLinkAPIDispatch.cpp
+        $${SDK_PATH}/DeckLinkAPIDispatch.cpp
 
 HEADERS +=
 

--- a/decklinkpreferences.pro
+++ b/decklinkpreferences.pro
@@ -15,10 +15,10 @@ CONFIG   -= app_bundle
 TEMPLATE = app
 
 
-INCLUDEPATH += /usr/include/decklink
+INCLUDEPATH += $HOME/pixelizator/bmdtools/Linux/include
 
 SOURCES += main.cpp \
-        /usr/include/decklink/DeckLinkAPIDispatch.cpp
+        $HOME/pixelizator/bmdtools/Linux/include/DeckLinkAPIDispatch.cpp
 
 HEADERS +=
 


### PR DESCRIPTION
I think it is better to use system environment variable instead editing `decklinkpreferences.pro` so I've made modification which allows to run qmake with variable with path to include catalog. I hope so you'll like this change.